### PR TITLE
Release xproc-engine-api v1.2.0

### DIFF
--- a/xproc-engine-api/pom.xml
+++ b/xproc-engine-api/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   
   <artifactId>xproc-engine-api</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>xproc-engine-api</name>
   <build>
@@ -21,8 +21,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <scm>
-    <tag>xproc-engine-api-1.2.0</tag>
-  </scm>
 </project>

--- a/xproc-engine-api/pom.xml
+++ b/xproc-engine-api/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   
   <artifactId>xproc-engine-api</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.0</version>
   <packaging>bundle</packaging>
   <name>xproc-engine-api</name>
   <build>
@@ -21,4 +21,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>xproc-engine-api-1.2.0</tag>
+  </scm>
 </project>


### PR DESCRIPTION
staged: https://oss.sonatype.org/content/repositories/orgdaisy-1784