### PR TITLE
Release xproc-engine-api v1.3.0

### DIFF
--- a/xproc-engine-api/pom.xml
+++ b/xproc-engine-api/pom.xml
@@ -11,7 +11,7 @@
   
   <groupId>org.daisy.maven</groupId>
   <artifactId>xproc-engine-api</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>xproc-engine-api</name>
   <build>
@@ -22,8 +22,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <scm>
-    <tag>v1.3.0</tag>
-  </scm>
 </project>

--- a/xproc-engine-api/pom.xml
+++ b/xproc-engine-api/pom.xml
@@ -11,7 +11,7 @@
   
   <groupId>org.daisy.maven</groupId>
   <artifactId>xproc-engine-api</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.0</version>
   <packaging>bundle</packaging>
   <name>xproc-engine-api</name>
   <build>
@@ -22,4 +22,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>v1.3.0</tag>
+  </scm>
 </project>

--- a/xprocspec-runner/pom.xml
+++ b/xprocspec-runner/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
staged: https://oss.sonatype.org/content/repositories/orgdaisy-2002